### PR TITLE
Fix typo in file extension

### DIFF
--- a/ftdetect/klog.vim
+++ b/ftdetect/klog.vim
@@ -1,1 +1,1 @@
-autocmd BufNewFile,BufRead *.kolg,*.klg set filetype=klog
+autocmd BufNewFile,BufRead *.klog,*.klg set filetype=klog


### PR DESCRIPTION
I suppose it was meant to be `.klog`, not `.kolg` 🙂