### PR TITLE
Add syntax highlighting of tag values

### DIFF
--- a/syntax/klog.vim
+++ b/syntax/klog.vim
@@ -4,7 +4,9 @@ if exists("b:current_syntax")
 endif
 
 " everywhere
-syntax match klogTag "#\S\+" contained
+syntax match klogTag "#[a-zA-Z0-9_-]\+" contained nextgroup=klogTagEquals
+syntax match klogTagEquals "=" contained nextgroup=klogTagValue
+syntax match klogTagValue "\(\"[^\"]*\"\|'[^']*'\|[a-zA-Z0-9_-]\+\)" contained
 
 " Record Header
 syntax region klogHeader start="^\d\{4}-\d\{2}-\d\{2}" end="$" contains=klogRecord,klogShould  nextgroup=klogRecordSummary,klogEntry skipnl
@@ -25,6 +27,7 @@ syntax match klogTimespan "\(^\t\|\ \{2,4}\)\@<=<\=\d\{1,2}:\d\{2}\(\(am\)\|\(pm
 
 " Highlight
 highlight default link klogTag Identifier
+highlight default link klogTagValue String
 highlight default link klogRecord Underlined
 highlight default link klogShould Statement
 highlight default link klogRecordSummary Comment


### PR DESCRIPTION
Implements proper syntax highlighting for tag values.

Before:
![vim-klog-before](https://github.com/user-attachments/assets/76d37e82-be16-4047-a8f4-6515242feeef)

After:
![vim-klog-after](https://github.com/user-attachments/assets/34935299-8011-4404-97db-3d484b09a2b7)

Also restricts the characters allowed in tags to alphanumeric characters, underscores, and hyphens, to match the klog specification.