### PR TITLE
Make spaces in time ranges optional

### DIFF
--- a/syntax/klog.vim
+++ b/syntax/klog.vim
@@ -22,8 +22,8 @@ syntax region klogEntry start="^\t\|\ \{2,4}-\(\d\+h\d\+m\|\d\+h\|\d\+m\)" end="
 syntax match klogNegDuration "\(^\t\|\ \{2,4}\)\@<=-\(\d\+h\d\+m\|\d\+h\|\d\+m\)" contained
 syntax region klogEntry start="^\t\|\ \{2,4}\(\d\+h\d\+m\|\d\+h\|\d\+m\)" end="$" contained keepend contains=klogTag,klogPosDuration nextgroup=klogEntrySummary,klogEntry skipnl
 syntax match klogPosDuration "\(^\t\|\ \{2,4}\)\@<=\(\d\+h\d\+m\|\d\+h\|\d\+m\)" contained
-syntax region klogEntry start="^\t\|\ \{2,4}<\=\d\{1,2}:\d\{2}\(\(am\)\|\(pm\)\)\=>\= - \(?\+\|\(\d\{1,2}:\d\{2}\(\(am\)\|\(pm\)\)\=>\=\)\)" end="$" contained keepend contains=klogTag,klogTimespan nextgroup=klogEntrySummary,klogEntry skipnl
-syntax match klogTimespan "\(^\t\|\ \{2,4}\)\@<=<\=\d\{1,2}:\d\{2}\(\(am\)\|\(pm\)\)\=>\= - \(?\+\|\(\d\{1,2}:\d\{2}\(\(am\)\|\(pm\)\)\=>\=\)\)" contained
+syntax region klogEntry start="^\t\|\ \{2,4}<\=\d\{1,2}:\d\{2}\(\(am\)\|\(pm\)\)\=>\=\s*-\s*\(?\+\|\(\d\{1,2}:\d\{2}\(\(am\)\|\(pm\)\)\=>\=\)\)" end="$" contained keepend contains=klogTag,klogTimespan nextgroup=klogEntrySummary,klogEntry skipnl
+syntax match klogTimespan "\(^\t\|\ \{2,4}\)\@<=<\=\d\{1,2}:\d\{2}\(\(am\)\|\(pm\)\)\=>\=\s*-\s*\(?\+\|\(\d\{1,2}:\d\{2}\(\(am\)\|\(pm\)\)\=>\=\)\)" contained
 
 " Highlight
 highlight default link klogTag Identifier


### PR DESCRIPTION
According to the specification [1], the spaces around the hyphen in time ranges should be optional and may be several.

Here are examples of legal ranges:

    12:00-14:00           <<<
    12:00 - 14:00
    12:00  -  14:00       <<<
    12:00 -14:00          <<<
    12:00- 14:00          <<<
    <12:00 -14:00         <<<
    <12:00 - 14:00>
    12:00- 14:00>         <<<

With this commit, those marked with three less-than signs (<<<) are now also adequately highlighted in Vim.