### PR TITLE
Handle leading plus-sign in duration entries

### DIFF
--- a/syntax/klog.vim
+++ b/syntax/klog.vim
@@ -20,8 +20,8 @@ syntax region klogRecordSummary start="^\S" end="$" contained contains=klogTag n
 syntax match klogEntrySummary "^\t\{2}\|\ \{4,8}.*" contained keepend contains=klogTag nextgroup=klogEntrySummary,klogEntry skipnl
 syntax region klogEntry start="^\t\|\ \{2,4}-\(\d\+h\d\+m\|\d\+h\|\d\+m\)" end="$" contained keepend contains=klogTag,klogNegDuration nextgroup=klogEntrySummary,klogEntry skipnl
 syntax match klogNegDuration "\(^\t\|\ \{2,4}\)\@<=-\(\d\+h\d\+m\|\d\+h\|\d\+m\)" contained
-syntax region klogEntry start="^\t\|\ \{2,4}\(\d\+h\d\+m\|\d\+h\|\d\+m\)" end="$" contained keepend contains=klogTag,klogPosDuration nextgroup=klogEntrySummary,klogEntry skipnl
-syntax match klogPosDuration "\(^\t\|\ \{2,4}\)\@<=\(\d\+h\d\+m\|\d\+h\|\d\+m\)" contained
+syntax region klogEntry start="^\t\|\ \{2,4}+\?\(\d\+h\d\+m\|\d\+h\|\d\+m\)" end="$" contained keepend contains=klogTag,klogPosDuration nextgroup=klogEntrySummary,klogEntry skipnl
+syntax match klogPosDuration "\(^\t\|\ \{2,4}\)\@<=+\?\(\d\+h\d\+m\|\d\+h\|\d\+m\)" contained
 syntax region klogEntry start="^\t\|\ \{2,4}<\=\d\{1,2}:\d\{2}\(\(am\)\|\(pm\)\)\=>\= - \(?\+\|\(\d\{1,2}:\d\{2}\(\(am\)\|\(pm\)\)\=>\=\)\)" end="$" contained keepend contains=klogTag,klogTimespan nextgroup=klogEntrySummary,klogEntry skipnl
 syntax match klogTimespan "\(^\t\|\ \{2,4}\)\@<=<\=\d\{1,2}:\d\{2}\(\(am\)\|\(pm\)\)\=>\= - \(?\+\|\(\d\{1,2}:\d\{2}\(\(am\)\|\(pm\)\)\=>\=\)\)" contained
 


### PR DESCRIPTION
According to the specification [1], a duration being positive may be indicated by a leading + character, e.g.: +4h12m.

Here are examples of legal durations:

    1h
    1h30m
    30m
    -1h
    -1h30m
    -30m
    +1h            <<<
    +1h30m         <<<
    +30m           <<<

With this commit, the ones marked with three less-than signs (<<<) are now also adequately highlighted in Vim.

[1]: https://github.com/jotaen/klog/blob/main/Specification.md#duration